### PR TITLE
fix the bug about use ctx.isSafeDomain

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,7 +7,7 @@ module.exports = app => {
   // if security plugin enabled, and origin config is not provided, will only allow safe domains support CORS.
   app.config.cors.origin = app.config.cors.origin || function corsOrigin(ctx) {
     const origin = ctx.get('origin');
-    if (!ctx.isSafeDomain || ctx.isSafeDomain(origin)) {
+    if (!ctx.isSafeDomain || ctx.isSafeDomain(origin, app.config.security.domainWhiteList)) {
       return origin;
     }
     return '';


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes

##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->
```js
ctx.isSafeDomain(origin)
```
=>

```js
ctx.isSafeDomain(origin, app.config.security.domainWhiteList)
```

##### Description of change
<!-- Provide a description of the change below this comment. -->

在使用 `egg-cors` 进行跨域资源共享的时候，发现无论域名白名单如何配置，`ctx.ctx.isSafeDomain(origin)` 总返回 `false`。查看 [`egg-security`](https://github.com/eggjs/egg-security.git) 中关于 [`isSafeDomain`](https://github.com/eggjs/egg-security/blob/master/lib/utils.js) 方法的源码的时候，发现需要传入 `domain_white_list`，但是在 egg-cors 的源码中没有传入。
