### PR TITLE
add types defination of cors options.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,6 +4,11 @@ declare module 'egg' {
     cors: {
       origin: string | (() => string);
       allowMethods: string | string[];
+      exposeHeaders?: string | string[];
+      allowHeaders?: string | string[];
+      maxAge?: string | number;
+      credentials?: boolean;
+      keepHeadersOnError?: boolean;
     }
   };
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes


##### Affected core subsystem(s)
<!-- Provide affected core subsystem(s). -->


##### Description of change
<!-- Provide a description of the change below this comment. -->
The Configuration section of egg-cors documents said "Support all configurations in kcors."
When I set the `credentials: true` in `config.cors`, the typescript will throw errors. 
So should add the defination of options to `index.d.ts`.
