### PR TITLE
fix: should also check origin with port

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,7 +13,7 @@ module.exports = app => {
     if (!origin) return '';
 
     const parsedUrl = url.parse(origin);
-    if (!ctx.isSafeDomain || ctx.isSafeDomain(parsedUrl.hostname)) {
+    if (!ctx.isSafeDomain || ctx.isSafeDomain(parsedUrl.hostname) || ctx.isSafeDomain(origin)) {
       return origin;
     }
     return '';

--- a/test/cors.test.js
+++ b/test/cors.test.js
@@ -47,6 +47,36 @@ describe('test/cors.test.js', () => {
       .expect(200);
   });
 
+  it('should set `Access-Control-Allow-Origin` to white list domain with protocol', () => {
+    return request(app.callback())
+      .get('/')
+      .set('Origin', 'https://a.com')
+      .expect('Access-Control-Allow-Origin', 'https://a.com')
+      .expect('Access-Control-Allow-Credentials', 'true')
+      .expect({ foo: 'bar' })
+      .expect(200);
+  });
+
+  it('should set `Access-Control-Allow-Origin` to white list domain with protocol and port', () => {
+    return request(app.callback())
+      .get('/')
+      .set('Origin', 'https://b.com:1234')
+      .expect('Access-Control-Allow-Origin', 'https://b.com:1234')
+      .expect('Access-Control-Allow-Credentials', 'true')
+      .expect({ foo: 'bar' })
+      .expect(200);
+  });
+
+  it('should set `Access-Control-Allow-Origin` to white list domain with protocol, wildcard and port', () => {
+    return request(app.callback())
+      .get('/')
+      .set('Origin', 'https://x.c.com')
+      .expect('Access-Control-Allow-Origin', 'https://x.c.com')
+      .expect('Access-Control-Allow-Credentials', 'true')
+      .expect({ foo: 'bar' })
+      .expect(200);
+  });
+
   it('should set `Access-Control-Allow-Origin` to request origin header with port', () => {
     return request(app.callback())
       .get('/')

--- a/test/fixtures/apps/cors/config/config.default.js
+++ b/test/fixtures/apps/cors/config/config.default.js
@@ -9,5 +9,8 @@ exports.cors = {
 exports.security = {
   domainWhiteList: [
     '.eggjs.org',
+    'https://a.com',
+    'https://b.com:1234',
+    'https://*.c.com',
   ],
 };


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.
Bug fixes and new features should include tests and possibly benchmarks.
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md

感谢您贡献代码。请确认下列 checklist 的完成情况。
Bug 修复和新功能必须包含测试，必要时请附上性能测试。
Contributors guide: https://github.com/eggjs/egg/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] tests and/or benchmarks are included
- [x] commit message follows commit guidelines

##### Description of change
<!-- Provide a description of the change below this comment. -->

恢复对包含协议和端口的白名单域名的支持。
2.2.1 版本为了增加对二级域名白名单的支持将 origin 校验修改成了提取 hostname 校验，导致带协议和端口号的白名单域名无法通过校验，而 egg 的文档和代码中都明确支持这种形式的白名单。


