### PR TITLE
feat: use @koa/cors@5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "cors"
   ],
   "dependencies": {
-    "@koa/cors": "^3.3.0"
+    "@koa/cors": "^5.0.0"
   },
   "devDependencies": {
     "egg": "^3.17.5",
@@ -30,11 +30,11 @@
     "egg-mock": "^5.10.9",
     "egg-security": "^3.1.0",
     "eslint": "^8.55.0",
-    "eslint-config-egg": "^12.3.1",
+    "eslint-config-egg": "12",
     "git-contributor": "^2.1.5"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=14.0.0"
   },
   "scripts": {
     "contributor": "git-contributor",

--- a/test/cors.default-config.test.js
+++ b/test/cors.default-config.test.js
@@ -19,7 +19,7 @@ describe('test/cors.default-config.test.js', () => {
       .get('/')
       .expect({ foo: 'bar' })
       .expect(res => {
-        assert(!res.headers['access-control-allow-origin']);
+        assert.equal(res.headers['access-control-allow-origin'], undefined);
       })
       .expect(200);
   });
@@ -31,7 +31,7 @@ describe('test/cors.default-config.test.js', () => {
       .expect('Access-Control-Allow-Credentials', 'true')
       .expect({ foo: 'bar' })
       .expect(res => {
-        assert(!res.headers['access-control-allow-origin']);
+        assert.equal(res.headers['access-control-allow-origin'], undefined);
       })
       .expect(200);
   });

--- a/test/cors.origin-function.test.js
+++ b/test/cors.origin-function.test.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const assert = require('assert');
 const mm = require('egg-mock');
 
@@ -21,7 +19,7 @@ describe('test/cors.origin-function.test.js', () => {
       .get('/')
       .expect({ foo: 'bar' })
       .expect(res => {
-        assert(!res.headers['access-control-allow-origin']);
+        assert.equal(res.headers['access-control-allow-origin'], undefined);
       })
       .expect(200);
   });

--- a/test/cors.origin.test.js
+++ b/test/cors.origin.test.js
@@ -16,12 +16,12 @@ describe('test/cors.origin.test.js', () => {
 
   afterEach(mm.restore);
 
-  it('should not set `Access-Control-Allow-Origin` when request Origin header missing', () => {
+  it('should alway set `Access-Control-Allow-Origin` to config.origin=string when request Origin header missing', () => {
     return app.httpRequest()
       .get('/')
       .expect({ foo: 'bar' })
       .expect(res => {
-        assert(!res.headers['access-control-allow-origin']);
+        assert.equal(res.headers['access-control-allow-origin'], 'eggjs.org');
       })
       .expect(200);
   });

--- a/test/fixtures/apps/cors.origin-function/config/config.default.js
+++ b/test/fixtures/apps/cors.origin-function/config/config.default.js
@@ -1,9 +1,8 @@
-'use strict';
-
 exports.keys = 'foo';
 
 exports.cors = {
-  async origin() {
+  async origin(ctx) {
+    if (!ctx.get('origin')) return '';
     return 'eggjs.org';
   },
   credentials: true,

--- a/test/fixtures/apps/cors.origin/config/config.default.js
+++ b/test/fixtures/apps/cors.origin/config/config.default.js
@@ -1,5 +1,3 @@
-'use strict';
-
 exports.keys = 'foo';
 
 exports.cors = {


### PR DESCRIPTION
BREAKING CHANGE: drop Node.js < 14

https://github.com/eggjs/egg/issues/5257
